### PR TITLE
Add Termux building support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,14 @@ ARCH ?= arm64-v8a
 
 TOOLCHAIN = $(NDK_PATH)/toolchains/llvm/prebuilt/linux-x86_64
 SYSROOT = $(TOOLCHAIN)/sysroot
-CC = $(TOOLCHAIN)/bin/clang
-AR = $(TOOLCHAIN)/bin/llvm-ar
+
+ifeq ($(TERMUX_VERSION),)
+	CC = $(TOOLCHAIN)/bin/clang
+	AR = $(TOOLCHAIN)/bin/llvm-ar
+else
+	CC = clang
+	AR = llvm-ar
+endif
 
 TARGET_arm64-v8a = aarch64-linux-android$(API_LEVEL)
 TARGET_armeabi-v7a = armv7a-linux-androideabi$(API_LEVEL)


### PR DESCRIPTION
Use the path's bins instead of ndk's when $TERMUX_VERSION is set.